### PR TITLE
Remove malloc null checks

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -59,9 +59,6 @@ pub(crate) unsafe fn yaml_string_extend(
         *start as *mut libc::c_void,
         ((*end).c_offset_from(*start) as libc::c_long * 2_i64) as size_t,
     ) as *mut yaml_char_t;
-    if new_start.is_null() {
-        return FAIL;
-    }
     memset(
         new_start.wrapping_offset((*end).c_offset_from(*start) as libc::c_long as isize)
             as *mut libc::c_void,
@@ -118,9 +115,6 @@ pub(crate) unsafe fn yaml_stack_extend(
         ((*end as *mut libc::c_char).c_offset_from(*start as *mut libc::c_char) as libc::c_long
             * 2_i64) as size_t,
     );
-    if new_start.is_null() {
-        return FAIL;
-    }
     *top = (new_start as *mut libc::c_char).wrapping_offset(
         (*top as *mut libc::c_char).c_offset_from(*start as *mut libc::c_char) as libc::c_long
             as isize,
@@ -145,9 +139,6 @@ pub(crate) unsafe fn yaml_queue_extend(
             ((*end as *mut libc::c_char).c_offset_from(*start as *mut libc::c_char) as libc::c_long
                 * 2_i64) as size_t,
         );
-        if new_start.is_null() {
-            return FAIL;
-        }
         *head = (new_start as *mut libc::c_char).wrapping_offset(
             (*head as *mut libc::c_char).c_offset_from(*start as *mut libc::c_char) as libc::c_long
                 as isize,
@@ -697,13 +688,9 @@ pub unsafe fn yaml_document_start_event_initialize(
     if !version_directive.is_null() {
         version_directive_copy = yaml_malloc(size_of::<yaml_version_directive_t>() as libc::c_ulong)
             as *mut yaml_version_directive_t;
-        if version_directive_copy.is_null() {
-            current_block = 14964981520188694172;
-        } else {
-            (*version_directive_copy).major = (*version_directive).major;
-            (*version_directive_copy).minor = (*version_directive).minor;
-            current_block = 1394248824506584008;
-        }
+        (*version_directive_copy).major = (*version_directive).major;
+        (*version_directive_copy).minor = (*version_directive).minor;
+        current_block = 1394248824506584008;
     } else {
         current_block = 1394248824506584008;
     }
@@ -924,33 +911,31 @@ pub unsafe fn yaml_scalar_event_initialize(
                     }
                     if yaml_check_utf8(value, length as size_t).ok {
                         value_copy = yaml_malloc((length + 1) as size_t) as *mut yaml_char_t;
-                        if !value_copy.is_null() {
-                            memcpy(
-                                value_copy as *mut libc::c_void,
-                                value as *const libc::c_void,
-                                length as libc::c_ulong,
-                            );
-                            *value_copy.wrapping_offset(length as isize) = b'\0';
-                            memset(
-                                event as *mut libc::c_void,
-                                0,
-                                size_of::<yaml_event_t>() as libc::c_ulong,
-                            );
-                            (*event).type_ = YAML_SCALAR_EVENT;
-                            (*event).start_mark = mark;
-                            (*event).end_mark = mark;
-                            let fresh168 = addr_of_mut!((*event).data.scalar.anchor);
-                            *fresh168 = anchor_copy;
-                            let fresh169 = addr_of_mut!((*event).data.scalar.tag);
-                            *fresh169 = tag_copy;
-                            let fresh170 = addr_of_mut!((*event).data.scalar.value);
-                            *fresh170 = value_copy;
-                            (*event).data.scalar.length = length as size_t;
-                            (*event).data.scalar.plain_implicit = plain_implicit;
-                            (*event).data.scalar.quoted_implicit = quoted_implicit;
-                            (*event).data.scalar.style = style;
-                            return OK;
-                        }
+                        memcpy(
+                            value_copy as *mut libc::c_void,
+                            value as *const libc::c_void,
+                            length as libc::c_ulong,
+                        );
+                        *value_copy.wrapping_offset(length as isize) = b'\0';
+                        memset(
+                            event as *mut libc::c_void,
+                            0,
+                            size_of::<yaml_event_t>() as libc::c_ulong,
+                        );
+                        (*event).type_ = YAML_SCALAR_EVENT;
+                        (*event).start_mark = mark;
+                        (*event).end_mark = mark;
+                        let fresh168 = addr_of_mut!((*event).data.scalar.anchor);
+                        *fresh168 = anchor_copy;
+                        let fresh169 = addr_of_mut!((*event).data.scalar.tag);
+                        *fresh169 = tag_copy;
+                        let fresh170 = addr_of_mut!((*event).data.scalar.value);
+                        *fresh170 = value_copy;
+                        (*event).data.scalar.length = length as size_t;
+                        (*event).data.scalar.plain_implicit = plain_implicit;
+                        (*event).data.scalar.quoted_implicit = quoted_implicit;
+                        (*event).data.scalar.style = style;
+                        return OK;
                     }
                 }
             }
@@ -1253,13 +1238,9 @@ pub unsafe fn yaml_document_initialize(
             version_directive_copy =
                 yaml_malloc(size_of::<yaml_version_directive_t>() as libc::c_ulong)
                     as *mut yaml_version_directive_t;
-            if version_directive_copy.is_null() {
-                current_block = 8142820162064489797;
-            } else {
-                (*version_directive_copy).major = (*version_directive).major;
-                (*version_directive_copy).minor = (*version_directive).minor;
-                current_block = 7746791466490516765;
-            }
+            (*version_directive_copy).major = (*version_directive).major;
+            (*version_directive_copy).minor = (*version_directive).minor;
+            current_block = 7746791466490516765;
         } else {
             current_block = 7746791466490516765;
         }
@@ -1480,29 +1461,27 @@ pub unsafe fn yaml_document_add_scalar(
             }
             if yaml_check_utf8(value, length as size_t).ok {
                 value_copy = yaml_malloc((length + 1) as size_t) as *mut yaml_char_t;
-                if !value_copy.is_null() {
-                    memcpy(
-                        value_copy as *mut libc::c_void,
-                        value as *const libc::c_void,
-                        length as libc::c_ulong,
-                    );
-                    *value_copy.wrapping_offset(length as isize) = b'\0';
-                    memset(
-                        node as *mut libc::c_void,
-                        0,
-                        size_of::<yaml_node_t>() as libc::c_ulong,
-                    );
-                    (*node).type_ = YAML_SCALAR_NODE;
-                    (*node).tag = tag_copy;
-                    (*node).start_mark = mark;
-                    (*node).end_mark = mark;
-                    (*node).data.scalar.value = value_copy;
-                    (*node).data.scalar.length = length as size_t;
-                    (*node).data.scalar.style = style;
-                    if PUSH!(addr_of_mut!(context), (*document).nodes, *node).ok {
-                        return (*document).nodes.top.c_offset_from((*document).nodes.start)
-                            as libc::c_int;
-                    }
+                memcpy(
+                    value_copy as *mut libc::c_void,
+                    value as *const libc::c_void,
+                    length as libc::c_ulong,
+                );
+                *value_copy.wrapping_offset(length as isize) = b'\0';
+                memset(
+                    node as *mut libc::c_void,
+                    0,
+                    size_of::<yaml_node_t>() as libc::c_ulong,
+                );
+                (*node).type_ = YAML_SCALAR_NODE;
+                (*node).tag = tag_copy;
+                (*node).start_mark = mark;
+                (*node).end_mark = mark;
+                (*node).data.scalar.value = value_copy;
+                (*node).data.scalar.length = length as size_t;
+                (*node).data.scalar.style = style;
+                if PUSH!(addr_of_mut!(context), (*document).nodes, *node).ok {
+                    return (*document).nodes.top.c_offset_from((*document).nodes.start)
+                        as libc::c_int;
                 }
             }
         }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -2,18 +2,13 @@ macro_rules! BUFFER_INIT {
     ($context:expr, $buffer:expr, $size:expr) => {{
         let start = addr_of_mut!($buffer.start);
         *start = yaml_malloc($size as size_t) as *mut yaml_char_t;
-        if !(*start).is_null() {
-            let pointer = addr_of_mut!($buffer.pointer);
-            *pointer = $buffer.start;
-            let last = addr_of_mut!($buffer.last);
-            *last = *pointer;
-            let end = addr_of_mut!($buffer.end);
-            *end = $buffer.start.wrapping_add($size as usize);
-            OK
-        } else {
-            (*$context).error = YAML_MEMORY_ERROR;
-            FAIL
-        }
+        let pointer = addr_of_mut!($buffer.pointer);
+        *pointer = $buffer.start;
+        let last = addr_of_mut!($buffer.last);
+        *last = *pointer;
+        let end = addr_of_mut!($buffer.end);
+        *end = $buffer.start.wrapping_add($size as usize);
+        OK
     }};
 }
 
@@ -42,15 +37,10 @@ macro_rules! STRING_ASSIGN {
 macro_rules! STRING_INIT {
     ($context:expr, $string:expr) => {{
         $string.start = yaml_malloc(16) as *mut yaml_char_t;
-        if !$string.start.is_null() {
-            $string.pointer = $string.start;
-            $string.end = $string.start.wrapping_add(16);
-            memset($string.start as *mut libc::c_void, 0, 16);
-            OK
-        } else {
-            (*$context).error = YAML_MEMORY_ERROR;
-            FAIL
-        }
+        $string.pointer = $string.start;
+        $string.end = $string.start.wrapping_add(16);
+        memset($string.start as *mut libc::c_void, 0, 16);
+        OK
     }};
 }
 
@@ -374,14 +364,9 @@ macro_rules! COPY {
 macro_rules! STACK_INIT {
     ($context:expr, $stack:expr, $type:ty) => {{
         $stack.start = yaml_malloc(16 * size_of::<$type>() as libc::c_ulong) as *mut $type;
-        if !$stack.start.is_null() {
-            $stack.top = $stack.start;
-            $stack.end = $stack.start.offset(16_isize);
-            OK
-        } else {
-            (*$context).error = YAML_MEMORY_ERROR;
-            FAIL
-        }
+        $stack.top = $stack.start;
+        $stack.end = $stack.start.offset(16_isize);
+        OK
     }};
 }
 
@@ -448,15 +433,10 @@ macro_rules! POP {
 macro_rules! QUEUE_INIT {
     ($context:expr, $queue:expr, $type:ty) => {{
         $queue.start = yaml_malloc(16 * size_of::<$type>() as libc::c_ulong) as *mut $type;
-        if !$queue.start.is_null() {
-            $queue.tail = $queue.start;
-            $queue.head = $queue.tail;
-            $queue.end = $queue.start.offset(16_isize);
-            OK
-        } else {
-            (*$context).error = YAML_MEMORY_ERROR;
-            FAIL
-        }
+        $queue.tail = $queue.start;
+        $queue.head = $queue.tail;
+        $queue.end = $queue.start.offset(16_isize);
+        OK
     }};
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -519,32 +519,25 @@ unsafe fn yaml_parser_parse_node(
                                 tag = yaml_malloc(
                                     prefix_len.wrapping_add(suffix_len).wrapping_add(1_u64),
                                 ) as *mut yaml_char_t;
-                                if tag.is_null() {
-                                    (*parser).error = YAML_MEMORY_ERROR;
-                                    current_block = 17786380918591080555;
-                                    break;
-                                } else {
-                                    memcpy(
-                                        tag as *mut libc::c_void,
-                                        (*tag_directive).prefix as *const libc::c_void,
-                                        prefix_len,
-                                    );
-                                    memcpy(
-                                        tag.wrapping_offset(prefix_len as isize)
-                                            as *mut libc::c_void,
-                                        tag_suffix as *const libc::c_void,
-                                        suffix_len,
-                                    );
-                                    *tag.wrapping_offset(
-                                        prefix_len.wrapping_add(suffix_len) as isize
-                                    ) = b'\0';
-                                    yaml_free(tag_handle as *mut libc::c_void);
-                                    yaml_free(tag_suffix as *mut libc::c_void);
-                                    tag_suffix = ptr::null_mut::<yaml_char_t>();
-                                    tag_handle = tag_suffix;
-                                    current_block = 17728966195399430138;
-                                    break;
-                                }
+                                memcpy(
+                                    tag as *mut libc::c_void,
+                                    (*tag_directive).prefix as *const libc::c_void,
+                                    prefix_len,
+                                );
+                                memcpy(
+                                    tag.wrapping_offset(prefix_len as isize) as *mut libc::c_void,
+                                    tag_suffix as *const libc::c_void,
+                                    suffix_len,
+                                );
+                                *tag.wrapping_offset(
+                                    prefix_len.wrapping_add(suffix_len) as isize
+                                ) = b'\0';
+                                yaml_free(tag_handle as *mut libc::c_void);
+                                yaml_free(tag_suffix as *mut libc::c_void);
+                                tag_suffix = ptr::null_mut::<yaml_char_t>();
+                                tag_handle = tag_suffix;
+                                current_block = 17728966195399430138;
+                                break;
                             } else {
                                 tag_directive = tag_directive.wrapping_offset(1);
                             }
@@ -705,31 +698,27 @@ unsafe fn yaml_parser_parse_node(
                             return OK;
                         } else if !anchor.is_null() || !tag.is_null() {
                             let value: *mut yaml_char_t = yaml_malloc(1_u64) as *mut yaml_char_t;
-                            if value.is_null() {
-                                (*parser).error = YAML_MEMORY_ERROR;
-                            } else {
-                                *value = b'\0';
-                                (*parser).state = POP!((*parser).states);
-                                memset(
-                                    event as *mut libc::c_void,
-                                    0,
-                                    size_of::<yaml_event_t>() as libc::c_ulong,
-                                );
-                                (*event).type_ = YAML_SCALAR_EVENT;
-                                (*event).start_mark = start_mark;
-                                (*event).end_mark = end_mark;
-                                let fresh54 = addr_of_mut!((*event).data.scalar.anchor);
-                                *fresh54 = anchor;
-                                let fresh55 = addr_of_mut!((*event).data.scalar.tag);
-                                *fresh55 = tag;
-                                let fresh56 = addr_of_mut!((*event).data.scalar.value);
-                                *fresh56 = value;
-                                (*event).data.scalar.length = 0_u64;
-                                (*event).data.scalar.plain_implicit = implicit;
-                                (*event).data.scalar.quoted_implicit = false;
-                                (*event).data.scalar.style = YAML_PLAIN_SCALAR_STYLE;
-                                return OK;
-                            }
+                            *value = b'\0';
+                            (*parser).state = POP!((*parser).states);
+                            memset(
+                                event as *mut libc::c_void,
+                                0,
+                                size_of::<yaml_event_t>() as libc::c_ulong,
+                            );
+                            (*event).type_ = YAML_SCALAR_EVENT;
+                            (*event).start_mark = start_mark;
+                            (*event).end_mark = end_mark;
+                            let fresh54 = addr_of_mut!((*event).data.scalar.anchor);
+                            *fresh54 = anchor;
+                            let fresh55 = addr_of_mut!((*event).data.scalar.tag);
+                            *fresh55 = tag;
+                            let fresh56 = addr_of_mut!((*event).data.scalar.value);
+                            *fresh56 = value;
+                            (*event).data.scalar.length = 0_u64;
+                            (*event).data.scalar.plain_implicit = implicit;
+                            (*event).data.scalar.quoted_implicit = false;
+                            (*event).data.scalar.style = YAML_PLAIN_SCALAR_STYLE;
+                            return OK;
                         } else {
                             yaml_parser_set_parser_error_context(
                                 parser,
@@ -1257,15 +1246,11 @@ unsafe fn yaml_parser_parse_flow_mapping_value(
 }
 
 unsafe fn yaml_parser_process_empty_scalar(
-    mut parser: *mut yaml_parser_t,
+    _parser: *mut yaml_parser_t,
     mut event: *mut yaml_event_t,
     mark: yaml_mark_t,
 ) -> Success {
     let value: *mut yaml_char_t = yaml_malloc(1_u64) as *mut yaml_char_t;
-    if value.is_null() {
-        (*parser).error = YAML_MEMORY_ERROR;
-        return FAIL;
-    }
     *value = b'\0';
     memset(
         event as *mut libc::c_void,
@@ -1359,14 +1344,8 @@ unsafe fn yaml_parser_process_directives(
                         version_directive =
                             yaml_malloc(size_of::<yaml_version_directive_t>() as libc::c_ulong)
                                 as *mut yaml_version_directive_t;
-                        if version_directive.is_null() {
-                            (*parser).error = YAML_MEMORY_ERROR;
-                            current_block = 17143798186130252483;
-                            break;
-                        } else {
-                            (*version_directive).major = (*token).data.version_directive.major;
-                            (*version_directive).minor = (*token).data.version_directive.minor;
-                        }
+                        (*version_directive).major = (*token).data.version_directive.major;
+                        (*version_directive).minor = (*token).data.version_directive.minor;
                     }
                 } else if (*token).type_ == YAML_TAG_DIRECTIVE_TOKEN {
                     let value = yaml_tag_directive_t {


### PR DESCRIPTION
In Rust, OOM errors are not reported by returning null from malloc.