### PR TITLE
Add support for emitting Unicode characters over codepoint U+FFFF

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -187,6 +187,8 @@ macro_rules! IS_PRINTABLE {
                 },
                 _ => true,
             },
+            // U+10000 ... U+10FFFF
+            0xF0..=0xF4 => true,
             _ => false,
         }
     };


### PR DESCRIPTION
Previously the Rust string `"\u{1F389}"` would get emitted as the YAML double quoted scalar `"\U0001F389"`. Now it will be serialized as `🎉`.